### PR TITLE
Add component = cloud-content and transition the ticket to Backlog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.py[co]
+*/config
 .idea
 .vscode/
 .tox

--- a/jira/github_jira.py
+++ b/jira/github_jira.py
@@ -28,13 +28,21 @@ CLOUD_REPOS = ['ansible-collections/amazon.aws',
                'redhat-cop/cloud.aws_troubleshooting',
                'redhat-cop/cloud.azure_ops',
                'redhat-cop/cloud.gcp_ops',
+               'redhat-cop/cloud.terraform_ops',
 ]
 
 g = Github(config['gh_token'])
-#jiraconn = JIRA(token_auth=config[jira_token']), server=config['jira_server'])
 jiraconn = JIRA(token_auth=config['jira_token'], server=config['jira_server'])
 
-jira_issues = jiraconn.search_issues('project=ACA and labels=github')
+jira_issues =  []
+count = 0
+# A single call to search_issues returns 50(default) records
+while True:
+  issues = jiraconn.search_issues('project=ACA and labels=github', count)
+  if not issues:
+    break
+  jira_issues.extend(issues)
+  count+=50
 
 # Component are resource objects
 prj_components = jiraconn.project_components(project='ACA')
@@ -55,8 +63,9 @@ for repo_name in CLOUD_REPOS:
     github_issues.extend(issues)
 
 to_create = []
+jira_things = [jira_obj.fields.description for jira_obj in jira_issues]
 for bug in github_issues:
-    jira_things = [jira_obj.fields.description for jira_obj in jira_issues]
+    # jira_things = [jira_obj.fields.description for jira_obj in jira_issues]
     # If the Github URL does not appear in any github-labelled Jira issue descriptions, we will a new Jira bug
     if not any([bug.html_url in jira_obj.fields.description for jira_obj in jira_issues]):
         to_create.append(bug)
@@ -80,7 +89,7 @@ for bug in to_create:
         'issuetype': {'name': 'Bug'},
         'labels': ['github', label],
         'priority': {'name': 'Undefined'},
-        'components': [{'name': component.name}],
+        'components': [{'name': component.name}, {'name': 'cloud-content'}],
         'versions':  [{'id': '12398634'}],
     }
 #versions = jiraconn.project_versions('ACA')
@@ -88,4 +97,6 @@ for bug in to_create:
 #[<JIRA Version: name='2.5', id='12401238'>, <JIRA Version: name='Unspecified', id='12398634'>, <JIRA Version: name='2.4', id='12397364'>, <JIRA Version: name='2.3', id='12385838'>]
     issue = jiraconn.create_issue(fields=issue_template)
     print(issue.id)
+    # Transition the issue from New to Backlog
+    jiraconn.transition_issue(issue.id, "Backlog")
 

--- a/jira/github_jira.py
+++ b/jira/github_jira.py
@@ -33,16 +33,7 @@ CLOUD_REPOS = ['ansible-collections/amazon.aws',
 
 g = Github(config['gh_token'])
 jiraconn = JIRA(token_auth=config['jira_token'], server=config['jira_server'])
-
-jira_issues =  []
-count = 0
-# A single call to search_issues returns 50(default) records
-while True:
-  issues = jiraconn.search_issues('project=ACA and labels=github', count)
-  if not issues:
-    break
-  jira_issues.extend(issues)
-  count+=50
+jira_issues = jiraconn.search_issues('project=ACA and labels=github', maxResults=1000)
 
 # Component are resource objects
 prj_components = jiraconn.project_components(project='ACA')


### PR DESCRIPTION
This PR incorporates the following improvements to the github_jira.py script:

- Appends "cloud-content" to the component field of the created Jira issue.
- Moves the Jira ticket from the New state to the Backlog state. This adjustment prevents any confusion between upstream issues originating from GitHub and downstream issues.