### PR TITLE
Add the Workstream field

### DIFF
--- a/jira/github_jira.py
+++ b/jira/github_jira.py
@@ -85,7 +85,7 @@ for bug in to_create:
         label = 'kubernetes'
         component = ctn_native_comp
 #    if bug.label = 'CI' or 'ci':
-
+    
     issue_template = {
         'project': 'ACA',
         'summary': '[{0}/{1}] {2}'.format(bug.repository.name, bug.number, bug.title),
@@ -95,6 +95,7 @@ for bug in to_create:
         'priority': {'name': 'Undefined'},
         'components': [{'name': component.name}, {'name': 'cloud-content'}],
         'versions':  [{'id': '12398634'}],
+        'customfield_12319275': [{'value': "Cloud Content"}], # This is the `Workstream` field
     }
 #versions = jiraconn.project_versions('ACA')
 #print([v for v in reversed(versions)])

--- a/jira/github_jira.py
+++ b/jira/github_jira.py
@@ -85,7 +85,6 @@ for bug in to_create:
         label = 'kubernetes'
         component = ctn_native_comp
 #    if bug.label = 'CI' or 'ci':
-    
     issue_template = {
         'project': 'ACA',
         'summary': '[{0}/{1}] {2}'.format(bug.repository.name, bug.number, bug.title),


### PR DESCRIPTION
The Workstream field is required in order for JIRAs to appear in our backlog / board. This PR adds the field to the JIRAs created by the script so we don't lose any JIRAs after running the script. 

Note: The Workstream field is a custom JIRA field, so it is referenced by its custom id (customfield_12319275)  in the script. 